### PR TITLE
Fix tab text color for bottom navigation

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -15,6 +15,10 @@ export default function TabLayout() {
           height: 60,
           paddingBottom: 5,
         },
+        tabBarLabelStyle: {
+          color: 'white',
+        },
+        tabBarLabelPosition: 'below-icon',
         headerShown: false,
       }}
     >


### PR DESCRIPTION
Update tab bar label style and position in `_layout.tsx`

* Add `tabBarLabelStyle` to `screenOptions` to set the text color to white
* Add `tabBarLabelPosition` to `screenOptions` to position the text below the icon

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mrmaligi/GSmopener/pull/4?shareId=53864a89-bb87-4ef7-8f17-cd72775a1abf).