### PR TITLE
Fix SMS issue in Expo app

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+  <uses-permission android:name="android.permission.SEND_SMS"/>
+  <uses-permission android:name="android.permission.READ_SMS"/>
   <queries>
     <intent>
       <action android:name="android.intent.action.VIEW"/>

--- a/app.json
+++ b/app.json
@@ -32,7 +32,8 @@
       }
     },
     "android": {
-      "package": "com.manikaran2007.boltexponativewind"
+      "package": "com.manikaran2007.boltexponativewind",
+      "permissions": ["SEND_SMS", "READ_SMS"]
     }
   }
 }


### PR DESCRIPTION
Fix the issue with the SMS functionality in the Expo app.

* **app/(tabs)/home.tsx**:
  - Add a console log to verify the `unitNumber` value in the `loadData` function.
  - Update the `sendSMS` function to validate the `unitNumber` and refine the SMS URL formation.
  - Improve error handling with more specific alerts in the `sendSMS` function.

* **app.json**:
  - Add the `android.permissions` section to request SMS-related permissions.

* **android/app/src/main/AndroidManifest.xml**:
  - Add permissions for sending and reading SMS.

